### PR TITLE
refactor: add shebang, strict mode, and use go install for Air runner

### DIFF
--- a/reload.sh
+++ b/reload.sh
@@ -1,2 +1,8 @@
-go get github.com/cosmtrek/air
-go run github.com/cosmtrek/air -c .air.toml server:start
+#!/usr/bin/env bash
+set -euo pipefail
+
+AIR_PACKAGE="github.com/cosmtrek/air"
+AIR_CONFIG=".air.toml"
+
+go install "${AIR_PACKAGE}@latest"
+go run "${AIR_PACKAGE}" -c "${AIR_CONFIG}" server:start


### PR DESCRIPTION
Refactor script for reloading to make it more reliable (exits on errors, undefined variables, etc), set `go install` instead of `go get` (since it's deprecated)

@donknap fyi