### PR TITLE
feat: add title and enable fields for site domain, support .disable config

### DIFF
--- a/app/application/http/controller/site-domain.go
+++ b/app/application/http/controller/site-domain.go
@@ -225,7 +225,7 @@ func (self SiteDomain) GetDetail(http *gin.Context) {
 		return
 	}
 
-	vhostFileName := fmt.Sprintf(logic.VhostFileName, domainRow.ServerName)
+	vhostFileName := domainRow.Setting.VHostFilename()
 	vhost, err := os.ReadFile(filepath.Join(storage.Local{}.GetNginxSettingPath(), vhostFileName))
 	if err != nil {
 		self.JsonResponseWithError(http, err, 500)
@@ -251,7 +251,7 @@ func (self SiteDomain) Delete(http *gin.Context) {
 	}
 	list, _ := dao.SiteDomain.Where(dao.SiteDomain.ID.In(params.Id...)).Find()
 	for _, item := range list {
-		err := os.Remove(filepath.Join(storage.Local{}.GetNginxSettingPath(), fmt.Sprintf(logic.VhostFileName, item.ServerName)))
+		err := os.Remove(filepath.Join(storage.Local{}.GetNginxSettingPath(), item.Setting.VHostFilename()))
 		if err != nil {
 			slog.Debug("container delete domain", "error", err)
 		}
@@ -411,7 +411,7 @@ func (self SiteDomain) UpdateVhost(http *gin.Context) {
 		return
 	}
 
-	nginxConfPath := filepath.Join(storage.Local{}.GetNginxSettingPath(), fmt.Sprintf(logic.VhostFileName, siteDomainRow.Setting.ServerName))
+	nginxConfPath := filepath.Join(storage.Local{}.GetNginxSettingPath(), siteDomainRow.Setting.VHostFilename())
 	err = os.WriteFile(nginxConfPath, []byte(params.Vhost), 0666)
 	if err != nil {
 		self.JsonResponseWithError(http, err, 500)

--- a/app/application/logic/site.go
+++ b/app/application/logic/site.go
@@ -191,12 +191,22 @@ func (self Site) MakeNginxConf(setting accessor.SiteDomainSettingOption) error {
 	if err != nil {
 		return err
 	}
-	confFileName := fmt.Sprintf(VhostFileName, setting.ServerName)
+
+	confFileName := setting.VHostFilename()
 	parser, err := template.ParseFS(asset, "asset/nginx/*.tpl")
 	if err != nil {
 		return err
 	}
-	vhostFile, err := os.OpenFile(filepath.Join(storage.Local{}.GetNginxSettingPath(), confFileName), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0666)
+
+	nginxSettingPath := storage.Local{}.GetNginxSettingPath()
+
+	// 删除该域名的所有配置文件（包括 .conf 和 .disable）
+	matchedFiles, _ := filepath.Glob(filepath.Join(nginxSettingPath, setting.ServerName+".conf*"))
+	for _, file := range matchedFiles {
+		_ = os.Remove(file)
+	}
+
+	vhostFile, err := os.OpenFile(filepath.Join(nginxSettingPath, confFileName), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0666)
 	if err != nil {
 		return errors.New("the Nginx configuration directory does not exist")
 	}

--- a/common/accessor/site_domain_setting_option.go
+++ b/common/accessor/site_domain_setting_option.go
@@ -1,6 +1,7 @@
 package accessor
 
 import (
+	"fmt"
 	"html/template"
 )
 
@@ -23,4 +24,15 @@ type SiteDomainSettingOption struct {
 	Type                      string        `json:"type"`
 	WWWRoot                   string        `json:"wwwRoot,omitempty"`
 	FPMRoot                   string        `json:"fpmRoot,omitempty"`
+	Title                     string        `json:"title,omitempty"` // 域名描述说明
+	Enable                    bool          `json:"enable"`          // 是否启用配置，false 时生成 .disable 文件
+}
+
+// VHostFilename 返回 vhost 配置文件名
+// 当 Enable 为 false 时，返回 .disable 后缀的文件名以跳过 nginx 加载
+func (s *SiteDomainSettingOption) VHostFilename() string {
+	if s.Enable {
+		return fmt.Sprintf("%s.conf", s.ServerName)
+	}
+	return fmt.Sprintf("%s.disable", s.ServerName)
 }


### PR DESCRIPTION
## Summary
- Add `title` field to SiteDomainSettingOption for domain description
- Add `enable` field to control whether nginx config is loaded
- When enable=false, generate `.disable` suffix file to skip nginx include
- Add VHostFilename() method to unified config filename handling
- Cleanup old config files using glob pattern when state changes