### PR TITLE
Fix formatting in README for Docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ lite 版去掉了域名转发相关，需要自行转发域名绑定容器，不
 ```
 docker run -d --name dpanel --restart=always \
  -p 8807:8080 -e APP_NAME=dpanel \
- -v /var/run/docker.sock:/var/run/docker.sock 
+ -v /var/run/docker.sock:/var/run/docker.sock \
  -v /home/dpanel:/dpanel dpanel/dpanel:lite
 ```
 


### PR DESCRIPTION
README 中 Lite 版本的 `docker run` 命令在 docker.sock 挂载这一行缺少续行符 `\`。

该问题会导致命令在复制执行时被拆分为两条，从而执行失败。

### 问题

原始内容：
```
-v /var/run/docker.sock:/var/run/docker.sock 
-v /home/dpanel:/dpanel dpanel/dpanel:lite
```

由于第一行末尾缺少 `\`，第二行会被当作新的命令执行。

### 修复

补充缺失的续行符：
```
docker run -d --name dpanel --restart=always \
  -p 8807:8080 \
  -e APP_NAME=dpanel \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v /home/dpanel:/dpanel \
  dpanel/dpanel:lite
```
修复后命令可正常复制并执行。

---

The `docker run` command in the Lite section of the README is missing a line-continuation backslash (`\`) after the docker.sock volume mount.

As a result, when the command is copied and executed, it is split into two separate shell commands and fails.

### Problem

Original:
```
-v /var/run/docker.sock:/var/run/docker.sock 
-v /home/dpanel:/dpanel dpanel/dpanel:lite
```
Since the first line does not end with `\`, the second line is interpreted as a new command.

### Fix

Add the missing backslash:
```
docker run -d --name dpanel --restart=always \
  -p 8807:8080 \
  -e APP_NAME=dpanel \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v /home/dpanel:/dpanel \
  dpanel/dpanel:lite
```
After this change, the command can be copied and executed correctly.